### PR TITLE
Clarify startup params and README for status server

### DIFF
--- a/status-server/README.md
+++ b/status-server/README.md
@@ -29,9 +29,20 @@ Or, load /status.html and click 'Update' to set the field value as your new stat
 Multiple status
 ---------------
 
-To be able to work with two or more status, just you need to start the server with a specific status (eg: status1, status0) and different port.
-We know the default port is 3000, you can use 4000 for example to start the second one and sure in different terminal.
+To be able to work with two or more status, you can create status{n} files in the data directory (e.g. status0, status1) The /status route has been changed and now matches for /status0.json, /status1.json etc.
+
+Startup parameters
+------------------
+
+The port the server listens on defaults to 3000, but can be configured by passing a --port parameter, for example
 
 ```
-node src\index.js --filename port 4000
+node src/index.js --port 8080
 ```
+
+The filename prefix we use is 'status', i.e. the server expects to find files named status0, status1 etc in the data directory. That prefix can be changed using the --prefix parameter, for example:
+
+```
+node src/index.js --prefix foo
+```
+

--- a/status-server/src/index.js
+++ b/status-server/src/index.js
@@ -90,10 +90,6 @@ app.post('/'+config.prefix+':num\.:ext?', function (req, res) {
   });
 });
 
-app.post('/message:num\.:ext?', function (req, res) {
-  // send a rainbow message to user
-});
-
 app.use(serveIndex(publicDir, {'icons': true}));
 
 app.listen(config.port, function () {

--- a/status-server/src/index.js
+++ b/status-server/src/index.js
@@ -10,7 +10,7 @@ var dataDir = path.join(__dirname, '../data');
 var publicDir = path.join(__dirname, 'public');
 var config = {
   port: 3000,
-  filename: 'status0'
+  prefix: 'status'
 };
 // mixin command-line args into our default config
 Object.keys(config).forEach(function(name) {
@@ -26,9 +26,9 @@ app.use(bodyParser.urlencoded({
 
 app.use(express.static(publicDir));
 
-app.get('/status:num\.:ext?', function (req, res) {
+app.get('/'+config.prefix+':num\.:ext?', function (req, res) {
   var num = req.params.num || 0;
-  var filename = path.join(dataDir, 'status' + num);
+  var filename = path.join(dataDir, config.prefix + num);
   var ext = req.params.ext || '';
   fs.readFile(filename, function(err, buf) {
     if (err) {
@@ -58,9 +58,9 @@ app.get('/status:num\.:ext?', function (req, res) {
   });
 });
 
-app.post('/status:num\.:ext?', function (req, res) {
+app.post('/'+config.prefix+':num\.:ext?', function (req, res) {
   var num = req.params.num || 0;
-  var filename = path.join(dataDir, 'status' + num);
+  var filename = path.join(dataDir, 'prefix' + num);
   var ext = req.params.ext || '';
   var status = req.body.value;
   fs.writeFile(filename, status, function(err, buf) {
@@ -88,6 +88,10 @@ app.post('/status:num\.:ext?', function (req, res) {
     });
 
   });
+});
+
+app.post('/message:num\.:ext?', function (req, res) {
+  // send a rainbow message to user
 });
 
 app.use(serveIndex(publicDir, {'icons': true}));


### PR DESCRIPTION
My bad on merging that last README change without looking at it carefully. The 'filename' parameter doesnt really make sense anymore, so I've changed that to read 'prefix', but I suspect we aint gonna need it. The port param will be useful when we come to provision this as a web-visible service