### PR TITLE
Config object and refactor initialization

### DIFF
--- a/status-server/src/public/example.html
+++ b/status-server/src/public/example.html
@@ -21,32 +21,9 @@
     <input type="button" value="Start"
 	         onclick="togglePolling(this);" />
   </section>
-  <script type="text/javascript">
-  //led0
-  var c = document.getElementById("led0");
-  var ctx = c.getContext("2d");
-  ctx.fillStyle = "#ff00ff";
-  ctx.fillRect(0,0,300,300);
-  //led1
-  var c1 = document.getElementById("led1");
-  var ctx1 = c1.getContext("2d");
-  ctx1.fillStyle = "#ffff00";
-  ctx1.fillRect(0,0,300,300);
-  //led2
-  var c2 = document.getElementById("led2");
-  var ctx2 = c2.getContext("2d");
-  ctx2.fillStyle = "#00ffff";
-  ctx2.fillRect(0,0,300,300);
-  //led3
-  var c3 = document.getElementById("led3");
-  var ctx3 = c3.getContext("2d");
-  ctx3.fillStyle = "#00ff07";
-  ctx3.fillRect(0,0,300,300);
-  //led4
-  var c4 = document.getElementById("led4");
-  var ctx4 = c4.getContext("2d");
-  ctx4.fillStyle = "#772cb6";
-  ctx4.fillRect(0,0,300,300);
-  </script>
+<script src="./js/config.js"></script>
 <script src="./js/client.js"></script>
+<script type="text/javascript">
+  init();
+</script>
 </body></html>

--- a/status-server/src/public/js/client.js
+++ b/status-server/src/public/js/client.js
@@ -33,6 +33,24 @@ function togglePolling(btn) {
   }
 }
 
+function init() {
+  // update the main heading if this client instance was passed an id
+  if (config && config.id) {
+    var titleNode = document.querySelector('h1');
+    if (titleNode) {
+      titleNode.innerHTML = 'status client: ' + config.id;
+    }
+  }
+  // populate the LEDs with some initial colors
+  var colors = ['#ffff00', '#ffff00', '#00ffff', '#00ff07', '#772cb6'];
+  colors.forEach((color, idx) => {
+    var node = document.getElementById("led" + idx);
+    var ctx = node.getContext("2d");
+    ctx.fillStyle = color;
+    ctx.fillRect(0,0,300,300);
+  });
+}
+
 function requestStatus() {
   var fetchResponses = Object.keys(statusItems).map(url => {
     // make a request to /status.json every 10s

--- a/status-server/src/public/js/config.js
+++ b/status-server/src/public/js/config.js
@@ -1,0 +1,22 @@
+(function(global){
+  // export a config global
+  var config = global.config = {};
+
+  // pull config from querystring
+  var expectedKeys = { id: true };
+
+  var queryStr = location.search.substring(1);
+  var pairs, nameValue, params = {};
+  if(queryStr){
+    pairs = queryStr.split('&');
+    for(var i=0; i<pairs.length; i++) {
+      nameValue = pairs[i].split('=');
+      if(nameValue[0] && (nameValue[0] in expectedKeys)){
+        config[ nameValue[0] ] = nameValue[1];
+      }
+    }
+    if(i >= pairs.length && location.hash) {
+        config[ nameValue[0] ] += location.hash;
+    }
+  }
+})(window);


### PR DESCRIPTION
I moved the inline code that puts initial colors into the canvases into a new init function in client.js
The new config.js populates a window.config object with params we can pass via querystring when requesting the example client page, e.g. 
```
example.html?id=status1
```
To show how we might use that I swap out the main heading if that id has been defined. In practice we'll want to use it when sending and updating status, so we can perhaps conditionally or differently animate LEDs if the status update is from ourself for example. 
