### PR TITLE
Refactor loop code out of updateStatus and renderStatus, track isSelf

### DIFF
--- a/status-server/src/public/js/client.js
+++ b/status-server/src/public/js/client.js
@@ -65,56 +65,66 @@ function requestStatus() {
   });
 
   Promise.all(fetchResponses).then(results => {
-    updateStatus(results);
-    renderStatus();
+    var urlKeys = Object.keys(statusItems);
+    // update each status (model)
+    results.forEach((data, idx) => {
+      var urlKey = urlKeys[idx];
+      updateStatus(urlKey, data);
+    });
+    // ..then updating the rendering of each
+    urlKeys.forEach((urlKey, idx) => {
+      renderStatus(urlKey);
+    });
   });
 }
 
-function updateStatus(results) {
-  var urlKeys = Object.keys(statusItems);
-  results.forEach((data, idx) => {
-    var urlKey = urlKeys[idx];
-    var statusData = statusItems[urlKey];
+function updateStatus(urlKey, data) {
+  var statusData = statusItems[urlKey];
+  // the page can be loaded with a querystring like example.html?id=status1,
+  // the config.id is populated in config.js
+  var userId = urlKey.replace(/\/([^\.]+).json/, '$1');
+  // are we updating the status that represents ourself?
+  var isSelf = config && config.id === userId;
 
-    // store updated value, did the value change?
-    var value = data.value;
-    var didChange;
-    var lastModified = data['last-modified'];
-    if (value === statusData.value && lastModified == statusData.lastModified) {
-      didChange = false;
-    } else {
-      console.log('updateStatus with changed data', data);
-      didChange = true;
-    }
-    statusData.value = value;
-    statusData.lastModified = lastModified;
-    statusData.didChange = didChange;
-  });
+  // store updated value, did the value change?
+  var value = data.value;
+  var didChange;
+  var lastModified = data['last-modified'];
+  if (value === statusData.value && lastModified == statusData.lastModified) {
+    didChange = false;
+  } else {
+    console.log('updateStatus with changed data', data);
+    didChange = true;
+  }
+  statusData.value = value;
+  statusData.lastModified = lastModified;
+  statusData.didChange = didChange;
+  statusData.isSelf = isSelf;
 }
 
-function renderStatus() {
-  Object.keys(statusItems).forEach((url, idx) => {
-    var statusData = statusItems[url];
-    if (statusData.didChange) {
-      console.log('renderStatus:', url, statusData);
-      // could mock some LED sequ  ences here?
-      // and/or just print the status value and last-modified date for now
-      var led = document.getElementById("led"+idx).getContext('2d');
-      var color;
-      switch (statusData.value) {
-        case ':-(':
-        case ':(':
-        case '0':
-          color = 'red';
-          break;
-        case ':-)':
-        case ':)':
-        case '1':
-          color = 'green';
-          break;
-      }
-      led.fillStyle = color;
-      led.fillRect(0,0,40,40);
+function renderStatus(urlKey) {
+  var statusData = statusItems[urlKey];
+  var idx = Object.keys(statusItems).indexOf(urlKey);
+
+  if (statusData.didChange) {
+    console.log('renderStatus:', urlKey, statusData);
+    // could mock some LED sequ  ences here?
+    // and/or just print the status value and last-modified date for now
+    var led = document.getElementById("led"+idx).getContext('2d');
+    var color;
+    switch (statusData.value) {
+      case ':-(':
+      case ':(':
+      case '0':
+        color = 'red';
+        break;
+      case ':-)':
+      case ':)':
+      case '1':
+        color = 'green';
+        break;
     }
-  });
+    led.fillStyle = color;
+    led.fillRect(0,0,40,40);
+  }
 }


### PR DESCRIPTION
Having these functions operate on one status/model at a time should make them more reusable and seems to make more sense. I also added the isSelf property to the status data. Test this by loading e.g. 

[http://localhost:3000/example.html?id=status2](http://localhost:3000/example.html?id=status2)



