### PR TITLE
added start script to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Learn about the Project Haiku (former Project Smart Home) on the Mozilla wiki
 Follow our progress in our Github wiki
 * [https://github.com/mozilla/project_haiku.iot/wiki](https://github.com/mozilla/project_haiku.iot/wiki)
 * Github won't notify you when this wiki is updated, but you can [subscribe via RSS](https://github.com/mozilla/project_haiku.iot/wiki.atom).
+
+## Running Server
+
+To run the server, enter the `status-server` directory and run:
+
+```
+$ npm start
+```
+
+We're using `nodemon` to watch for changes and the server will automatically restart.

--- a/status-server/package.json
+++ b/status-server/package.json
@@ -1,8 +1,14 @@
 {
+  "scripts": {
+    "start": "nodemon ./src/index.js"
+  },
   "dependencies": {
     "body-parser": "^1.15.1",
     "express": "^4.13.4",
     "optimist": "^0.6.1",
     "serve-index": "^1.8.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.10.0"
   }
 }


### PR DESCRIPTION
To make it easier to start and work on the server I added the start-script to `package.json`. Now we can just use:

 ```
$ npm start 
```

and nodemon will detect changes and restart the server as needed. 